### PR TITLE
Recent scikit learn support

### DIFF
--- a/few/evaluation.py
+++ b/few/evaluation.py
@@ -13,8 +13,9 @@ import itertools as it
 import sys
 from sklearn.metrics.pairwise import pairwise_distances
 # from profilehooks import profile
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from sklearn.feature_selection import f_classif, f_regression
+
 # safe division
 def divs(x,y):
     """safe division"""

--- a/few/few.py
+++ b/few/few.py
@@ -23,7 +23,8 @@ from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.model_selection import cross_val_score, train_test_split, KFold
 from sklearn.metrics import r2_score, accuracy_score, roc_auc_score
-from sklearn.preprocessing import Imputer, StandardScaler
+from sklearn.preprocessing import StandardScaler
+from sklearn.impute import SimpleImputer
 from sklearn.utils import check_random_state
 from DistanceClassifier import DistanceClassifier
 import numpy as np
@@ -34,7 +35,7 @@ import itertools as it
 import pdb
 from collections import defaultdict
 # from update_checker import update_check
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from tqdm import tqdm
 import uuid
 
@@ -433,7 +434,7 @@ class FEW(SurvivalMixin, VariationMixin, EvaluationMixin, PopMixin,
 
     def impute_data(self,x):
         """Imputes data set containing Nan values"""
-        imp = Imputer(missing_values='NaN', strategy='mean', axis=0)
+        imp = SimpleImputer(missing_values='NaN', strategy='mean', axis=0)
         return imp.fit_transform(x)
 
     def clean(self,x):

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ e-mail: lacava@upenn.edu
 This project is hosted at https://github.com/lacava/few
 ''',
     zip_safe=True,
-    install_requires=['numpy', 'scipy', 'pandas', 'scikit-learn',
+    install_requires=['numpy', 'scipy', 'pandas', 'scikit-learn', 'joblib',
                       'update_checker', 'tqdm', 'joblib','DistanceClassifier',
                       'scikit-mdr','Cython', 'eigency'],
-    setup_requires=['numpy', 'scipy', 'pandas', 'scikit-learn',
+    setup_requires=['numpy', 'scipy', 'pandas', 'scikit-learn', 'joblib',
                       'update_checker', 'tqdm', 'joblib','DistanceClassifier',
                       'scikit-mdr','Cython', 'eigency'],
     classifiers=[


### PR DESCRIPTION
I was trying to test the package, but ran into a few issues with a recent scikit-learn.

Although not used, Parallel and delayed were imported. They no longer are in sklearn. Replaced the import to joblib. Also, Imputer is now SimpleImputer and no longer in preprocessing but in impute.

These changes allow for compatibility with scikit-learn 0.23